### PR TITLE
support select @@time_zone;

### DIFF
--- a/qinsql-mysql/src/main/java/org/qinsql/mysql/sql/expression/MySQLFunction.java
+++ b/qinsql-mysql/src/main/java/org/qinsql/mysql/sql/expression/MySQLFunction.java
@@ -9,4 +9,8 @@ public class MySQLFunction {
     public static int getConnectionId() {
         return 0;
     }
+
+    public static String getVersion() {
+        return "8.0.22";
+    }
 }

--- a/qinsql-mysql/src/main/java/org/qinsql/mysql/sql/expression/MySQLVariable.java
+++ b/qinsql-mysql/src/main/java/org/qinsql/mysql/sql/expression/MySQLVariable.java
@@ -6,6 +6,7 @@
 package org.qinsql.mysql.sql.expression;
 
 import java.sql.Connection;
+import java.util.TimeZone;
 
 import org.lealone.db.session.ServerSession;
 import org.lealone.db.value.Value;
@@ -29,7 +30,10 @@ public class MySQLVariable extends Variable {
             return ValueInt.get(1);
         case "tx_isolation":
             return ValueString.get(getTransactionIsolationLevel(session));
-        }
+        case "time_zone":
+        case "system_time_zone":
+            return ValueString.get(TimeZone.getDefault().getID());
+        };
         return super.getValue(session);
     }
 


### PR DESCRIPTION
hive database gets NullPointerException because time_zone is null

MetaException(message:Failed initialising database. Please check that your database JDBC driver is accessible, and the database URL and username/password are correct. Exception : null
java.lang.NullPointerException
	at java.util.Calendar$Builder.setTimeZone(Calendar.java:1313)
	at sun.util.locale.provider.CalendarProviderImpl.getInstance(CalendarProviderImpl.java:86)
	at java.util.Calendar.createCalendar(Calendar.java:1666)
	at java.util.Calendar.getInstance(Calendar.java:1655)
	at com.mysql.cj.result.SqlDateValueFactory.<init>(SqlDateValueFactory.java:61)
	at com.mysql.cj.result.SqlDateValueFactory.<init>(SqlDateValueFactory.java:68)
	at com.mysql.cj.jdbc.result.ResultSetImpl.<init>(ResultSetImpl.java:270)
	at com.mysql.cj.jdbc.result.ResultSetFactory.createFromResultsetRows(ResultSetFactory.java:135)
	at com.mysql.cj.jdbc.DatabaseMetaData.getTypeInfo(DatabaseMetaData.java:4061)
